### PR TITLE
Fix row assignment for concurrent devices and add device selection UI

### DIFF
--- a/automation_web.py
+++ b/automation_web.py
@@ -251,7 +251,8 @@ def index():
         "index.html",
         status=status,
         csv_stats=csv_stats,
-        daily_folders=daily_folders
+        daily_folders=daily_folders,
+        devices=getattr(config, "DEVICES", []),
     )
 
 @app.route("/all/sort", methods=["POST"])
@@ -462,9 +463,11 @@ def run_batch_multi():
     dest_csv = os.path.join(config.BASE_DIR, folder, "hommes.csv" if gender == "men" else "femmes.csv")
     _ensure_csv(dest_csv, _safe_headers())
 
-    devices = getattr(config, "DEVICES", [])
+    selected_udids = request.form.getlist("devices")
+    all_devices = getattr(config, "DEVICES", [])
+    devices = [d for d in all_devices if d.get("udid") in selected_udids]
     if not devices:
-        flash("No devices configured in config.DEVICES.", "danger")
+        flash("Please select at least one device.", "danger")
         return redirect(url_for("index"))
 
     stop_event = threading.Event()
@@ -474,7 +477,9 @@ def run_batch_multi():
     # mark running for UI
     try:
         automation._STATE.set_running(True)
-        automation._STATE.set_step("multi-device batch", f"{len(devices)} device(s) → {folder} ({gender})")
+        automation._STATE.set_step(
+            "multi-device batch", f"{len(devices)} device(s) → {folder} ({gender})"
+        )
     except Exception:
         pass
 

--- a/rowstore.py
+++ b/rowstore.py
@@ -95,3 +95,72 @@ def append_row_dict(path: str, row_dict: Dict[str, str]):
         row_df = row_df[df.columns]
         new_df = pd.concat([df, row_df], ignore_index=True)
         save_df(new_df, path)
+
+
+def claim_next_row(path: str, worker_name: str) -> Tuple[Optional[pd.Series], bool]:
+    """
+    Find the first row whose WORKER column is empty and mark it with
+    ``worker_name`` so other workers ignore it.
+
+    Returns a tuple ``(row, has_rows)`` where ``row`` is the claimed row as
+    a Series (or ``None`` if none were available) and ``has_rows`` indicates
+    whether the source CSV had any rows at all.
+    """
+    with with_csv_lock(path):
+        df = load_df(path)
+        if df.empty:
+            return None, False
+
+        if "WORKER" not in df.columns:
+            df["WORKER"] = ""
+
+        mask = df["WORKER"].astype(str) == ""
+        if not mask.any():
+            # there are rows, but all claimed
+            return None, True
+
+        idx = df.index[mask][0]
+        df.at[idx, "WORKER"] = worker_name
+        save_df(df, path)
+        return df.loc[idx], True
+
+
+def finalize_row(
+    path: str,
+    worker_name: str,
+    row_dict: Dict[str, str],
+    *,
+    requeue: bool = False,
+):
+    """
+    Remove the row currently claimed by ``worker_name``. If ``requeue`` is
+    True, append ``row_dict`` back to the bottom (with WORKER cleared).
+    ``row_dict`` should contain the most up-to-date data for that row.
+    """
+    with with_csv_lock(path):
+        df = load_df(path)
+        if "WORKER" not in df.columns:
+            return
+
+        mask = df["WORKER"] == worker_name
+        if not mask.any():
+            return
+
+        idx = df.index[mask][0]
+        df = df.drop(idx).reset_index(drop=True)
+
+        if requeue:
+            # ensure WORKER column exists and is cleared
+            row_dict = dict(row_dict)
+            row_dict["WORKER"] = ""
+            row_df = pd.DataFrame([row_dict])
+            for c in df.columns:
+                if c not in row_df.columns:
+                    row_df[c] = ""
+            for c in row_df.columns:
+                if c not in df.columns:
+                    df[c] = ""
+            row_df = row_df[df.columns]
+            df = pd.concat([df, row_df], ignore_index=True)
+
+        save_df(df, path)

--- a/templates/index.html
+++ b/templates/index.html
@@ -157,9 +157,15 @@
                 <span class="badge bg-secondary me-3">{{ item.men_count }} men</span>
 
                 <!-- Action buttons -->
-                <form method="post" action="{{ url_for('run_batch_multi') }}" class="d-flex align-items-center ms-auto">
+                <form method="post" action="{{ url_for('run_batch_multi') }}" class="d-flex align-items-center ms-auto flex-wrap">
                   <input type="hidden" name="folder" value="{{ item.folder }}">
-                  <input type="number" name="count" value="1" min="1" class="form-control form-control-sm me-2" style="width:80px;">
+                  {% for dev in devices %}
+                    <div class="form-check form-check-inline mb-1">
+                      <input class="form-check-input" type="checkbox" name="devices" value="{{ dev.udid }}" id="dev-{{ loop.index }}-{{ loop.parent.index }}">
+                      <label class="form-check-label small" for="dev-{{ loop.index }}-{{ loop.parent.index }}">{{ dev.name or dev.udid }}</label>
+                    </div>
+                  {% endfor %}
+                  <input type="number" name="count" value="1" min="1" class="form-control form-control-sm ms-2 me-2" style="width:80px;">
                   <button type="submit" name="gender" value="men" class="btn btn-outline-primary btn-sm me-2">+ Men</button>
                   <button type="submit" name="gender" value="women" class="btn btn-outline-danger btn-sm">+ Women</button>
                 </form>

--- a/workers.py
+++ b/workers.py
@@ -1,6 +1,7 @@
 # workers.py
 from __future__ import annotations
 
+import os
 import time
 import threading
 from typing import Optional
@@ -9,7 +10,13 @@ import pandas as pd
 
 import automation
 import config
-from rowstore import with_csv_lock, load_df, save_df, rotate_row_to_bottom, append_row_dict
+from rowstore import (
+    load_df,
+    save_df,
+    append_row_dict,
+    claim_next_row,
+    finalize_row,
+)
 from login import run_login_on_row
 from CreationReservation import run_creation_on_row
 
@@ -32,7 +39,8 @@ except Exception:
 class DeviceWorker(threading.Thread):
     """
     One worker per device (udid). Keeps a persistent Appium driver alive.
-    Processes the FIRST row repeatedly until:
+    Claims the next unassigned row (using the WORKER column) and processes it
+    repeatedly until:
       - success_target reached (if provided)
       - src CSV is empty
       - stop_event is set
@@ -86,64 +94,68 @@ class DeviceWorker(threading.Thread):
                     self._status("success target reached")
                     break
 
-                # ---- Peek first row (WITHOUT removing) ----
-                with with_csv_lock(self.src_csv):
-                    df = load_df(self.src_csv)
-                    if df.empty:
+                # ---- Claim a free row via WORKER column ----
+                row_series, has_rows = claim_next_row(self.src_csv, self.label)
+                if row_series is None:
+                    if has_rows:
+                        # all rows currently claimed by other workers
+                        self._status("waiting for row")
+                        time.sleep(0.5)
+                        continue
+                    else:
                         self._status("source empty")
                         break
-                    row_index = 0
-                    row_series = df.iloc[row_index]
 
-                # ---- Run creation or login in-process (keep driver alive) ----
+                # Work on a temporary single-row CSV so run_* functions can mutate it
+                tmp_path = f"{self.src_csv}.{self.udid}.tmp.csv"
                 try:
-                    creation_flag = str(row_series.get("CREATION", "")).strip()
-                    if creation_flag == "1":
-                        self._status("login", f"row0={row_series.get('nom','')}")
-                        run_login_on_row(drv, row_index, row_series, self.src_csv, self.target_ddmm)
-                    else:
-                        self._status("creation", f"row0={row_series.get('nom','')}")
-                        run_creation_on_row(drv, row_index, row_series, self.src_csv, self.target_ddmm)
-                except Exception as e:
-                    # soft reset app; keep session alive
-                    self._status("row error", str(e))
+                    save_df(pd.DataFrame([row_series]), tmp_path)
+
+                    # ---- Run creation or login (keep driver alive) ----
                     try:
-                        hard_reset_app(drv, config.APP_PACKAGE)
-                    except Exception:
-                        pass
-                    # continue to routing with whatever is in the CSV now
+                        creation_flag = str(row_series.get("CREATION", "")).strip()
+                        if creation_flag == "1":
+                            self._status("login", f"row0={row_series.get('nom','')}")
+                            run_login_on_row(drv, 0, row_series, tmp_path, self.target_ddmm)
+                        else:
+                            self._status("creation", f"row0={row_series.get('nom','')}")
+                            run_creation_on_row(drv, 0, row_series, tmp_path, self.target_ddmm)
+                    except Exception as e:
+                        # soft reset app; keep session alive
+                        self._status("row error", str(e))
+                        try:
+                            hard_reset_app(drv, config.APP_PACKAGE)
+                        except Exception:
+                            pass
 
-                # ---- Check outcome on row 0 & route ----
-                with with_csv_lock(self.src_csv):
-                    df_after = load_df(self.src_csv)
+                    # ---- Check outcome & route ----
+                    df_after = load_df(tmp_path)
                     if df_after.empty:
-                        self._status("source empty after run")
-                        break
-
-                    row_after = df_after.iloc[0].to_dict()
+                        row_after = {}
+                    else:
+                        row_after = df_after.iloc[0].to_dict()
                     created = str(row_after.get("CREATION", "")).strip() == "1"
                     reserved = str(row_after.get("RESERVATION", "")).strip() == "1"
 
                     if created and reserved:
-                        # drop first from src
-                        rest = df_after.drop(df_after.index[0]).reset_index(drop=True)
-                        save_df(rest, self.src_csv)
-                        # append to destination
+                        row_after.pop("WORKER", None)
                         append_row_dict(self.dest_csv, row_after)
+                        finalize_row(self.src_csv, self.label, row_after, requeue=False)
                         self.success += 1
                         self._status("moved → dest", f"ok={self.success}")
                     else:
-                        # explicit fail? drop
                         if str(row_after.get("CREATION", "")).strip() == "-1":
-                            rest = df_after.drop(df_after.index[0]).reset_index(drop=True)
-                            save_df(rest, self.src_csv)
+                            finalize_row(self.src_csv, self.label, row_after, requeue=False)
                             self._status("dropped (CREATION=-1)")
                         else:
-                            # rotate to bottom (keep columns aligned)
-                            rest = df_after.drop(df_after.index[0]).reset_index(drop=True)
-                            save_df(rest, self.src_csv)
-                            rotate_row_to_bottom(self.src_csv, row_after)
+                            finalize_row(self.src_csv, self.label, row_after, requeue=True)
                             self._status("rotated to bottom")
+
+                finally:
+                    try:
+                        os.remove(tmp_path)
+                    except Exception:
+                        pass
 
                 self.processed += 1
                 time.sleep(0.05)  # tiny breather


### PR DESCRIPTION
## Summary
- prevent multiple devices from working on the same CSV row by reserving a WORKER column and clearing it after processing
- allow selecting specific devices for a batch via the web UI

## Testing
- `python -m py_compile automation_web.py workers.py rowstore.py`


------
https://chatgpt.com/codex/tasks/task_e_68c039ccfa18832193ed0cda8b6c4658